### PR TITLE
修复Windows下使用Python运行时报错的Bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,5 @@ input
 output
 __pycache_
 logos/logo_psds
-exiftool
 build
 dist


### PR DESCRIPTION
### 修改内容

- 增加 `exiftool.exe`

### 原因

在 Windows 下使用 `python main.py` 运行程序时，由于缺少 `exiftool.exe` ，会报下列错误

```
Traceback (most recent call last):
  File "D:\semi-utils\main.py", line 115, in <module>
    processing()
  File "D:\semi-utils\main.py", line 57, in processing
    container = ImageContainer(source_path)
  File "D:\semi-utils\entity\image_container.py", line 50, in __init__
    self.exif: dict = get_exif(path)
  File "D:\semi-utils\utils.py", line 40, in get_exif
    output = subprocess.check_output([EXIFTOOL_PATH, '-charset', 'UTF8', path])
  File "D:\Environment\Miniconda3\lib\subprocess.py", line 424, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
  File "D:\Environment\Miniconda3\lib\subprocess.py", line 505, in run
    with Popen(*popenargs, **kwargs) as process:
  File "D:\Environment\Miniconda3\lib\subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "D:\Environment\Miniconda3\lib\subprocess.py", line 1420, in _execute_child
    hp, ht, pid, tid = _winapi.CreateProcess(executable, args,
FileNotFoundError: [WinError 2] 系统找不到指定的文件。
```