### PR TITLE
fix: 修复无法获取镜头信息

### DIFF
--- a/entity/image_container.py
+++ b/entity/image_container.py
@@ -23,7 +23,7 @@ logger = logging.getLogger(__name__)
 class ExifId(Enum):
     CAMERA_MODEL = 'CameraModelName'
     CAMERA_MAKE = 'Make'
-    LENS_MODEL = ['LensModel', 'Lens']
+    LENS_MODEL = ['LensModel', 'Lens', 'LensID']
     LENS_MAKE = 'LensMake'
     DATETIME = 'DateTimeOriginal'
     FOCAL_LENGTH = 'FocalLength'


### PR DESCRIPTION
部分镜头的exif信息字段为`Lens ID`

![CleanShot 2024-06-03 at 15 58 21](https://github.com/leslievan/semi-utils/assets/16473062/3796ae21-f123-47bb-bf0e-335da6d7eb79)
