### PR TITLE
feat: 检测下载的 exiftool tar.gz 的完整性

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,27 +1,39 @@
 #!/bin/bash
 
-if [ -f 'inited' ]; then
-  echo '已完成初始化, 开始运行(如需重新初始化, 请删除 inited 文件)'
+EXIFTOOL_FILE_NAME="Image-ExifTool-12.92.tar.gz"
+EXIFTOOL_FILE_DOWNLOAD_URL="http://file.lsvm.xyz/Image-ExifTool-12.92.tar.gz"
+
+if [ -f "inited" ]; then
+  echo "已完成初始化, 开始运行(如需重新初始化, 请删除 inited 文件)"
   exit 0
 fi
 
 # 下载文件
-curl -O http://file.lsvm.xyz/Image-ExifTool-12.92.tar.gz
+curl -O $EXIFTOOL_FILE_DOWNLOAD_URL
 
+# 测试 gzip 压缩的有效性
+if ! gzip -t "$EXIFTOOL_FILE_NAME"; then
+    echo "下载的 ExifTool gzip 压缩文件格式不正确"
+    echo "请检查 url 的有效性： $EXIFTOOL_FILE_DOWNLOAD_URL"
+    echo "当前下载的 ExifTool gzip 的格式为："
+    file "$EXIFTOOL_FILE_NAME"
+    echo "安装未完成，初始化脚本中断"
+    exit 1
+fi
 
 # 创建目录
 mkdir -p ./exiftool
 
 # 解压文件
-tar -xzf Image-ExifTool-12.92.tar.gz -C ./exiftool --strip-components=1
+tar -xzf "$EXIFTOOL_FILE_NAME" -C ./exiftool --strip-components=1
 
 # 删除压缩包
-rm Image-ExifTool-12.92.tar.gz
+rm "$EXIFTOOL_FILE_NAME"
 
 # 下载 python 依赖
 pip3 install -r requirements.txt -i https://pypi.tuna.tsinghua.edu.cn/simple
 
 # 初始化完成
 touch inited
-echo '初始化完成, inited 文件已生成, 如需重新初始化, 请删除 inited 文件'
+echo "初始化完成, inited 文件已生成, 如需重新初始化, 请删除 inited 文件"
 exit 0


### PR DESCRIPTION
### 问题的出现
我今天刚接触到这个工具，准备在我的 Linux 上使用。在执行 `install.sh` 后，脚本顺利执行完成。但是，在我随后执行 python 脚本时，输出的图片的所有参数信息都是空的。

### 调查
由于初始化脚本正常输出了**初始化完成**，所以我最一开始没有怀疑是初始化脚本出了问题。在本项目的帮助文档中查询一番后，我发现本项目依赖 exiftool；所以我在怀疑，我的设备上是否缺乏 exiftool 的依赖。由于我的设备是 Ubuntu，所以我执行了：
```shell
sudo apt install libimage-exiftool-perl
```
果然，在安装好 exiftool 的依赖后，semi-utils 的 python 脚本输出的图片，正常显示了图片的参数。
![image with arguments](https://github.com/user-attachments/assets/6dde6d81-04e3-4bf4-9f5a-8561d83ea32c)
（注：这些参数在我修复之前是空的，比如形如 `- - - -`  这样，当时忘记截图了）
不过，根本原因，真的是如此么？

### 结束了吗？
我总觉得，初始化脚本理应帮我配置好依赖才对。于是，我倒查了初始化脚本的log，在字里行间发现了这么一段内容
```
gzip: stdin: not in gzip format
tar: Child returned status 1
tar: Error is not recoverable: exiting now
```
难道是下载的 gzip 有问题？我看了下安装脚本；安装脚本在解包、解压“完成”后，就把 gzip 删除了。于是，我只能执行一遍在初始化脚本中实际被执行过了的 curl，下载脚本中的 gzip：
```shell
curl -O http://file.lsvm.xyz/Image-ExifTool-12.92.tar.gz
```
 hexdump 了一下下载的 gzip，果然：
![image](https://github.com/user-attachments/assets/6a56321b-5408-4581-b11c-fc0aeba8e395)

所以，初始化脚本没有任何检测 gzip 有效性的逻辑，就把这么一个 302 的 HTML 放过去了；然后，解压失败，重要依赖缺失，初始化脚本也不 abort，还把作案现场给清理掉了：这个有问题的 gzip 被悄无声息地删掉了。

### 解决方案
见本 pr 的 commit，增加检测 gz 有效性的逻辑，在 gz 无效时给出实际的文件类型、下载 url 、报错并 abort。以下是实现本解决方案后， gzip 出错时的输出：
![image](https://github.com/user-attachments/assets/e772758a-dfbc-4799-9aef-4c7b95951409)
