### PR TITLE
fix: install.sh中原ExifTool镜像失效，替换为新地址

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,7 +6,7 @@ if [ -f 'inited' ]; then
 fi
 
 # 下载文件
-curl -O http://file.lsvm.xyz/Image-ExifTool-12.92.tar.gz
+curl -O https://sources.voidlinux.org/exiftool-12.92/Image-ExifTool-12.92.tar.gz
 
 
 # 创建目录


### PR DESCRIPTION
镜像失效，使用新的地址进行替换