### PR TITLE
fix: exiftool 缺失时明确报错，补全依赖与快速开始文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,41 @@
 如果您觉得程序对您有所帮助的话，可以点击 [Sponsor](https:/su/cdn.lsvm.xyz/wechat.jpg) 按钮请作者喝杯咖啡，谢谢！
 
 
-## 开发文档
+## 快速开始
 
-**[Wiki](../../wiki)**
+### 1. 环境要求
+
+- **Python ≥ 3.13**
+- **exiftool**：读取照片 EXIF 信息（相机型号、镜头、光圈、快门、ISO、拍摄时间等）必需。它是独立的命令行程序，**不是 Python 包，无法通过 pip/uv 安装**，需单独安装：
+  - macOS：`brew install exiftool`
+  - Linux：`sudo apt install libimage-exiftool-perl`
+  - Windows：从 [exiftool.org](https://exiftool.org/) 下载，解压到项目的 `./exiftool/` 目录
+  > ⚠️ 缺少 exiftool 时程序仍能启动，但生成的图片不会有任何水印文字和品牌 Logo。
+
+### 2. 运行
+
+#### 方式一：uv（推荐）
+
+[uv](https://docs.astral.sh/uv/) 会自动安装匹配的 Python 版本，并按 `uv.lock` 锁定依赖：
+
+```bash
+uv run app.py
+```
+
+#### 方式二：init.sh（没有 uv 时）
+
+脚本会校验 Python 版本、创建虚拟环境、安装依赖，并检测 exiftool（macOS 上用 Homebrew 自动安装；其他系统若缺少则提示手动安装并退出），最后启动：
+
+```bash
+./init.sh
+```
+
+### 3. 使用
+
+启动后会自动打开浏览器访问 **http://localhost:15050**（若未自动打开，手动访问该地址即可）。在网页里选择照片所在文件夹、挑选水印模板，点击处理即可。处理后的图片会输出到 `output/` 目录。
+
+> 端口、输入/输出目录、输出质量、默认模板等均可在 `config/config.ini` 中修改。
+
 
 ## 效果展示
 
@@ -26,6 +58,11 @@
 | [normal1](./static/normal1.json)       | 极简风格，右下角显示拍摄参数，低调不抢眼 | ![normal1](./static/normal1.jpeg)       |
 | [normal2](./static/normal2.json)       | 文件夹名称+拍摄时间，橙色文字，简洁实用 | ![normal2](./static/normal2.jpeg)       |
 | [center_logo](./static/center_logo.json) | 中心 Logo 水印，可自定义四周文字内容 | ![center_logo](./static/center_logo.jpeg)       |
+
+
+## 开发文档
+
+**[Wiki](../../wiki)**
 
 
 ## 许可证

--- a/core/util.py
+++ b/core/util.py
@@ -5,6 +5,7 @@ import platform
 import re
 import shutil
 import subprocess
+import sys
 import time
 from functools import wraps
 from pathlib import Path
@@ -16,15 +17,39 @@ from core.configs import templates_dir
 from core.jinja2renders import vh, vw, auto_logo
 from core.logger import logger
 
-if platform.system() == 'Windows':
-    EXIFTOOL_PATH = Path('./exiftool/exiftool.exe')
-    ENCODING = 'gbk'
-elif shutil.which('exiftool') is not None:
-    EXIFTOOL_PATH = shutil.which('exiftool')
-    ENCODING = 'utf-8'
-else:
-    EXIFTOOL_PATH = Path('./exiftool/exiftool')
-    ENCODING = 'utf-8'
+# 项目自带 exiftool 二进制的根目录（基于本文件定位，不依赖当前工作目录）
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _resolve_exiftool():
+    """解析可用的 exiftool 路径，找不到返回 None。"""
+    if platform.system() == 'Windows':
+        bundled = _PROJECT_ROOT / 'exiftool' / 'exiftool.exe'
+        return str(bundled) if bundled.exists() else None
+    # 优先使用系统 PATH 中的 exiftool
+    found = shutil.which('exiftool')
+    if found:
+        return found
+    # 退而求其次：项目自带的二进制
+    bundled = _PROJECT_ROOT / 'exiftool' / 'exiftool'
+    return str(bundled) if bundled.exists() else None
+
+
+EXIFTOOL_PATH = _resolve_exiftool()
+ENCODING = 'gbk' if platform.system() == 'Windows' else 'utf-8'
+
+EXIFTOOL_MISSING_HINT = (
+    "未找到 exiftool，无法读取照片 EXIF，生成的水印将没有任何文字和 Logo。\n"
+    "请安装后重试：\n"
+    "  macOS:  brew install exiftool\n"
+    "  Linux:  sudo apt install libimage-exiftool-perl\n"
+    "  其他:   从 https://exiftool.org 下载并解压到项目的 ./exiftool/ 目录"
+)
+
+# 此处仍在 init_from_config 之前，loguru 尚未注册 handler，
+# 故用 stderr 直接输出，确保启动时该提示一定可见。
+if EXIFTOOL_PATH is None:
+    print(EXIFTOOL_MISSING_HINT, file=sys.stderr)
 
 
 def get_exif(path) -> dict:
@@ -33,6 +58,8 @@ def get_exif(path) -> dict:
     :param path: 照片路径
     :return: exif信息
     """
+    if EXIFTOOL_PATH is None:
+        raise RuntimeError(EXIFTOOL_MISSING_HINT)
     exif_dict = {}
     try:
         output_bytes = subprocess.check_output([EXIFTOOL_PATH, '-d', '%Y-%m-%d %H:%M:%S%3f%z', path])

--- a/init.sh
+++ b/init.sh
@@ -11,8 +11,20 @@ NC='\033[0m' # No Color
 
 echo -e "${BOLD}${BLUE}🚀 开始初始化项目环境${NC}\n"
 
-# 检查 Python 版本
+# 检查 Python 版本（项目要求 >= 3.13）
+if ! command -v python3 &> /dev/null; then
+    echo -e "${RED}✗  未找到 python3，请先安装 Python 3.13 及以上版本${NC}"
+    exit 1
+fi
 PYTHON_VERSION=$(python3 --version 2>&1 | awk '{print $2}')
+PY_MAJOR=$(echo "$PYTHON_VERSION" | cut -d. -f1)
+PY_MINOR=$(echo "$PYTHON_VERSION" | cut -d. -f2)
+if [ "$PY_MAJOR" -lt 3 ] || { [ "$PY_MAJOR" -eq 3 ] && [ "$PY_MINOR" -lt 13 ]; }; then
+    echo -e "${RED}✗  当前 python3 版本为 ${BOLD}$PYTHON_VERSION${NC}${RED}，但本项目要求 Python >= 3.13${NC}"
+    echo -e "${YELLOW}   推荐改用 uv 运行（会自动安装 3.13）：${BOLD}uv run app.py${NC}"
+    echo -e "${YELLOW}   或安装 Python 3.13 后重试。${NC}"
+    exit 1
+fi
 echo -e "${GREEN}✓  Python 已安装, 版本: ${BOLD}$PYTHON_VERSION${NC}"
 
 # 创建虚拟环境
@@ -34,6 +46,28 @@ echo -e "${GREEN}-  安装项目依赖...${NC}"
 pip install -i https://mirrors.tuna.tsinghua.edu.cn/pypi/web/simple \
     -r requirements.txt
 echo -e "${GREEN}✓  依赖安装完成${NC}"
+
+# 检查 exiftool（读取照片 EXIF 必需，是独立命令行程序，pip 无法安装）
+echo -e "${GREEN}-  检查 exiftool...${NC}"
+if command -v exiftool &> /dev/null; then
+    echo -e "${GREEN}✓  exiftool 已安装${NC}"
+else
+    echo -e "${YELLOW}!  未检测到 exiftool（读取 EXIF 必需，缺失会导致水印没有文字和 Logo）${NC}"
+    if [[ "$OSTYPE" == "darwin"* ]] && command -v brew &> /dev/null; then
+        echo -e "${GREEN}-  通过 Homebrew 安装 exiftool...${NC}"
+        brew install exiftool || {
+            echo -e "${RED}✗  brew 安装 exiftool 失败，请手动安装：https://exiftool.org${NC}"
+            exit 1
+        }
+        echo -e "${GREEN}✓  exiftool 安装完成${NC}"
+    else
+        echo -e "${RED}✗  请手动安装 exiftool 后重试：${NC}"
+        echo -e "${YELLOW}     macOS:  brew install exiftool${NC}"
+        echo -e "${YELLOW}     Linux:  sudo apt install libimage-exiftool-perl${NC}"
+        echo -e "${YELLOW}     其他:   https://exiftool.org${NC}"
+        exit 1
+    fi
+fi
 
 echo ""
 echo -e "${BOLD}${GREEN}✅  环境初始化完成${NC}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
-flask
-jinja2
-numpy
-pillow
-pillow-heif
-loguru
-tomli
+# 与 pyproject.toml 的 dependencies 保持一致，改依赖时请两处同步
+flask>=3.1.2
+jinja2>=3.1.6
+loguru>=0.7.3
+numpy>=2.4.0
+pillow>=12.1.0
+pillow-heif>=1.1.1
+pystray>=0.19.5
+tomli>=2.3.0


### PR DESCRIPTION
- core/util.py: exiftool 不可用时 get_exif 抛出明确错误并在启动时告警， 不再静默返回空 EXIF 而生成没有水印文字/Logo 的图片
- init.sh: 增加 Python>=3.13 版本校验，以及 exiftool 检测与 macOS 自动安装
- requirements.txt: 与 pyproject.toml 依赖对齐（补 pystray 及版本约束，避免漂移）
- README.md: 新增「快速开始」（环境要求、uv/init.sh 两种运行方式、exiftool 安装说明）